### PR TITLE
Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,30 @@ To clean up the build (for example if you want to do a full rebuild), use the st
 make clean
 ```
 
+Installation under windows
+---------------
+1.  Installing under windows is almost the same as under linux machine. You need [cygwin](https://www.cygwin.com/), [make for windows](http://gnuwin32.sourceforge.net/packages/make.htm) and [gcc-arm toolchain](https://launchpad.net/gcc-arm-embedded) installed and added to path (so you can call `make` and `arm-none-eabi-gcc` from the command line). Although having cygwin in your path is necessary you don't (and probably shouldn't) run it under bash. Windows commandline is okay.
+
+2. Setup [python-evic](https://github.com/Ban3/python-evic) (Again, you need to be able to run evic from anywhere in cmd).
+
+3. Clone this repository:
+   ```
+   git clone https://github.com/ReservedField/evic-sdk.git
+   cd evic-sdk
+   ```
+
+4. Download the latest [M451 series SDK](http://www.nuvoton.com/hq/support/tool-and-software/software)
+   from Nuvoton and copy the `Library` folder inside `evic-sdk/nuvoton-sdk`, as to have
+   `evic-sdk/nuvoton-sdk/Library`.
+
+5. Set `EVICSKD` to point to your sdk location using **forward slashes** (this is very important), so it looks like this: `SET EVICSDK=C:/evic-sdk`
+
+6. You will also need to set `ARMGCC` variable poining to arm-none-eabi install location like `SET ARMGCC=D:/arm-none-eabi`. Again, remember about **forward slashes**
+
+7. Build the sdk with `make`.
+
+8. SDK should be compiled set up at this point.
+
 Building your first APROM
 --------------------------
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 eVic SDK is a software development kit for writing APROMs for the Joyetech eVic VTC Mini.
 
-Installation
+Installation under linux
 ---------------
 
 1. You need to setup an arm-none-eabi GCC toolchain and newlib.
@@ -43,20 +43,11 @@ Installation
    make
    ```
 
-At this point, the SDK should be fully set up. You can also generate Doxygen documentation with:
-```
-make docs
-```
-To clean up the build (for example if you want to do a full rebuild), use the standard:
-```
-make clean
-```
-
 Installation under windows
 ---------------
 1.  Installing under windows is almost the same as under linux machine. You need [cygwin](https://www.cygwin.com/), [make for windows](http://gnuwin32.sourceforge.net/packages/make.htm) and [gcc-arm toolchain](https://launchpad.net/gcc-arm-embedded) installed and added to path (so you can call `make` and `arm-none-eabi-gcc` from the command line). Although having cygwin in your path is necessary you don't (and probably shouldn't) run it under bash. Windows commandline is okay.
 
-2. Setup [python-evic](https://github.com/Ban3/python-evic) (Again, you need to be able to run evic from anywhere in cmd).
+2. Setup [python-evic](https://github.com/Ban3/python-evic) (Again, you need to be able to run `evic` from anywhere in cmd).
 
 3. Clone this repository:
    ```
@@ -70,11 +61,21 @@ Installation under windows
 
 5. Set `EVICSKD` to point to your sdk location using **forward slashes** (this is very important), so it looks like this: `SET EVICSDK=C:/evic-sdk`
 
-6. You will also need to set `ARMGCC` variable poining to arm-none-eabi install location like `SET ARMGCC=D:/arm-none-eabi`. Again, remember about **forward slashes**
+6. You will also need to set `ARMGCC` variable poining to arm-none-eabi install location like `SET ARMGCC=D:/arm-none-eabi`. The folder you point to should contain `bin`, `lib` and `arm-none-eabi` folders. Again, remember about **forward slashes**.
 
 7. Build the sdk with `make`.
 
-8. SDK should be compiled set up at this point.
+Making docs and cleaning up
+---------------
+
+At this point, the SDK should be fully set up. You can also generate Doxygen documentation with:
+```
+make docs
+```
+To clean up the build (for example if you want to do a full rebuild), use the standard:
+```
+make clean
+```
 
 Building your first APROM
 --------------------------

--- a/make/Base.mk
+++ b/make/Base.mk
@@ -29,9 +29,16 @@ INCDIRS = -I$(NUVOSDK)/CMSIS/Include \
 	-I$(EVICSDK)/include
 
 LDSCRIPT = $(EVICSDK)/linker/linker.ld
-LIBDIRS = -L/usr/arm-none-eabi/lib \
-   -L/usr/lib/gcc/arm-none-eabi/$(shell arm-none-eabi-gcc -v 2>&1 | grep '^gcc version' | awk '{print $$3}') \
-   -L$(EVICSDK)/lib
+
+ifeq ($(OS),Windows_NT)
+	LIBDIRS = -L$(ARMGCC)/arm-none-eabi/lib \
+			-L$(ARMGCC)/lib/gcc/arm-none-eabi/5.2.1
+else
+	LIBDIRS = -L/usr/arm-none-eabi/lib \
+			-L/usr/lib/gcc/arm-none-eabi/$(shell arm-none-eabi-gcc -v 2>&1 | grep '^gcc version' | awk '{print $$3}')
+endif
+
+LIBDIRS += -L$(EVICSDK)/lib  
 LIBS = -levicsdk
 
 CFLAGS += -Wall -mcpu=$(CPU) -mthumb -Os


### PR DESCRIPTION
I've added tutorial for windows and slightly modified the Base.mk file to satisfy linker. The steps I wrote down should be enough to compile and use the SDK under windows machine, tested from (almost) clean install.
