### PR TITLE
crt0 compile/link on linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,8 +103,7 @@ LD := arm-none-eabi-ld
 AR := arm-none-eabi-ar
 OBJCOPY := arm-none-eabi-objcopy
 
-INCDIRS := -I$(ARMGCC)/arm-none-eabi/include \
-	-I$(NUVOSDK)/CMSIS/Include \
+INCDIRS := -I$(NUVOSDK)/CMSIS/Include \
 	-I$(NUVOSDK)/Device/Nuvoton/M451Series/Include \
 	-I$(NUVOSDK)/StdDriver/inc \
 	-Iinclude

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,8 @@ AS := arm-none-eabi-as
 AR := arm-none-eabi-ar
 OBJCOPY := arm-none-eabi-objcopy
 
-INCDIRS := -I$(NUVOSDK)/CMSIS/Include \
+INCDIRS := -I$(ARMGCC)/arm-none-eabi/include \
+	-I$(NUVOSDK)/CMSIS/Include \
 	-I$(NUVOSDK)/Device/Nuvoton/M451Series/Include \
 	-I$(NUVOSDK)/StdDriver/inc \
 	-Iinclude

--- a/Makefile
+++ b/Makefile
@@ -89,13 +89,12 @@ AS := arm-none-eabi-as
 AR := arm-none-eabi-ar
 OBJCOPY := arm-none-eabi-objcopy
 
-INCDIRS := -I$(ARMGCC)/arm-none-eabi/include \
-	-I$(NUVOSDK)/CMSIS/Include \
+INCDIRS := -I$(NUVOSDK)/CMSIS/Include \
 	-I$(NUVOSDK)/Device/Nuvoton/M451Series/Include \
 	-I$(NUVOSDK)/StdDriver/inc \
 	-Iinclude
 
-CFLAGS += -Wall -mcpu=$(CPU) -mthumb -Os
+CFLAGS += -Wall -mcpu=$(CPU) -mthumb -Os -fdata-sections -ffunction-sections
 CFLAGS += $(INCDIRS)
 
 ASFLAGS := -mcpu=$(CPU)

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ ifneq ($(ARMGCC),)
 		EVICSDK := $(shell cygpath -w $(EVICSDK))
 	else
 		OBJS_FIXPATH := $(OBJS)
+		OBJS_CRT0_FIXPATH := $(OBJS_CRT0)
 	endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -89,12 +89,13 @@ AS := arm-none-eabi-as
 AR := arm-none-eabi-ar
 OBJCOPY := arm-none-eabi-objcopy
 
-INCDIRS := -I$(NUVOSDK)/CMSIS/Include \
+INCDIRS := -I$(ARMGCC)/arm-none-eabi/include \
+	-I$(NUVOSDK)/CMSIS/Include \
 	-I$(NUVOSDK)/Device/Nuvoton/M451Series/Include \
 	-I$(NUVOSDK)/StdDriver/inc \
 	-Iinclude
 
-CFLAGS += -Wall -mcpu=$(CPU) -mthumb -Os -fdata-sections -ffunction-sections
+CFLAGS += -Wall -mcpu=$(CPU) -mthumb -Os
 CFLAGS += $(INCDIRS)
 
 ASFLAGS := -mcpu=$(CPU)

--- a/make/Base.mk
+++ b/make/Base.mk
@@ -58,7 +58,8 @@ OBJCOPY := arm-none-eabi-objcopy
 
 BINDIR := bin
 
-INCDIRS := -I$(NUVOSDK)/CMSIS/Include \
+INCDIRS := -I$(ARMGCC)/arm-none-eabi/include \
+	-I$(NUVOSDK)/CMSIS/Include \
 	-I$(NUVOSDK)/Device/Nuvoton/M451Series/Include \
 	-I$(NUVOSDK)/StdDriver/inc \
 	-I$(EVICSDK)/include

--- a/make/Base.mk
+++ b/make/Base.mk
@@ -58,8 +58,7 @@ OBJCOPY := arm-none-eabi-objcopy
 
 BINDIR := bin
 
-INCDIRS := -I$(ARMGCC)/arm-none-eabi/include \
-	-I$(NUVOSDK)/CMSIS/Include \
+INCDIRS := -I$(NUVOSDK)/CMSIS/Include \
 	-I$(NUVOSDK)/Device/Nuvoton/M451Series/Include \
 	-I$(NUVOSDK)/StdDriver/inc \
 	-I$(EVICSDK)/include

--- a/make/Base.mk
+++ b/make/Base.mk
@@ -58,7 +58,8 @@ OBJCOPY := arm-none-eabi-objcopy
 
 BINDIR := bin
 
-INCDIRS := -I$(NUVOSDK)/CMSIS/Include \
+INCDIRS := -I$(ARMGCC)/arm-none-eabi/include \
+	-I$(NUVOSDK)/CMSIS/Include \
 	-I$(NUVOSDK)/Device/Nuvoton/M451Series/Include \
 	-I$(NUVOSDK)/StdDriver/inc \
 	-I$(EVICSDK)/include
@@ -72,14 +73,14 @@ LIBDIRS := -L$(ARMGCC)/arm-none-eabi/lib \
 
 LIBS := -levicsdk
 
-CFLAGS += -Wall -mcpu=$(CPU) -mthumb -Os -fdata-sections -ffunction-sections
+CFLAGS += -Wall -mcpu=$(CPU) -mthumb -Os
 CFLAGS += $(INCDIRS)
 
 ASFLAGS += -mcpu=$(CPU)
 
 LDFLAGS += $(LIBDIRS)
 LDFLAGS += $(LIBS)
-LDFLAGS += -nostdlib -nostartfiles -T$(LDSCRIPT) --gc-sections
+LDFLAGS += -nostdlib -nostartfiles -T$(LDSCRIPT)
 
 all: env_check $(TARGET).bin
 

--- a/make/Base.mk
+++ b/make/Base.mk
@@ -58,8 +58,7 @@ OBJCOPY := arm-none-eabi-objcopy
 
 BINDIR := bin
 
-INCDIRS := -I$(ARMGCC)/arm-none-eabi/include \
-	-I$(NUVOSDK)/CMSIS/Include \
+INCDIRS := -I$(NUVOSDK)/CMSIS/Include \
 	-I$(NUVOSDK)/Device/Nuvoton/M451Series/Include \
 	-I$(NUVOSDK)/StdDriver/inc \
 	-I$(EVICSDK)/include
@@ -73,14 +72,14 @@ LIBDIRS := -L$(ARMGCC)/arm-none-eabi/lib \
 
 LIBS := -levicsdk
 
-CFLAGS += -Wall -mcpu=$(CPU) -mthumb -Os
+CFLAGS += -Wall -mcpu=$(CPU) -mthumb -Os -fdata-sections -ffunction-sections
 CFLAGS += $(INCDIRS)
 
 ASFLAGS += -mcpu=$(CPU)
 
 LDFLAGS += $(LIBDIRS)
 LDFLAGS += $(LIBS)
-LDFLAGS += -nostdlib -nostartfiles -T$(LDSCRIPT)
+LDFLAGS += -nostdlib -nostartfiles -T$(LDSCRIPT) --gc-sections
 
 all: env_check $(TARGET).bin
 


### PR DESCRIPTION
Couldn't compile on linux because OBJS_CRT0_FIXPATH was "" here:
    $(LD) -r $(OBJS_CRT0_FIXPATH) -o $(OUTDIR)/$(TARGET_CRT0).o
