### PR TITLE
Added non-cygwin environment support on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ brew install gcc-arm-none-eabi
 
 On Windows, first install the [precompiled ARM toolchain](https://launchpad.net/gcc-arm-embedded).
 Choose an installation path without spaces to avoid problems with
-the build process. Then, install [Cygwin](https://www.cygwin.com/)
+the build process. Then, install [Cygwin](https://www.cygwin.com/) (for a non-cygwin environment please refer to pr ReservedField#20)
 and add the following packages on top of the base install:
 ```
 make


### PR DESCRIPTION
Hello, after multiple issues with cygwin, I decided to fix the issue with a non-cygwin env on windows.

This PR makes the makefile(s) not assume winuser is on cygwin.
To make use of this, please make sure that your PATH is set up to include things like Gnuwin32's `awk grep` and probably more.

Make sure that your `make` is set correctly, I use mingw.
Please test this to confirm that it works on all envs.
