### PR TITLE
fix Atomizer_ReadBoardTemp

### DIFF
--- a/src/atomizer/Atomizer.c
+++ b/src/atomizer/Atomizer.c
@@ -824,5 +824,5 @@ uint8_t Atomizer_ReadBoardTemp() {
 	// Interpolate
 	lowerBound = Atomizer_boardTempTable[i];
 	higherBound = Atomizer_boardTempTable[i - 1];
-	return 5 * (i - 1) + (thermRes - lowerBound) * 5 / (higherBound - lowerBound);
+	return 5 * i - (thermRes - lowerBound) * 5 / (higherBound - lowerBound);
 }


### PR DESCRIPTION
Atomizer_ReadBoardTemp had it backwards in the final calculation, making the temperatures incorrect. 

The fix was verified in a Presa 75 and seems to match the readings from the OFW.
